### PR TITLE
Fix NPE on clientId

### DIFF
--- a/src/main/java/me/figo/FigoConnection.java
+++ b/src/main/java/me/figo/FigoConnection.java
@@ -91,6 +91,7 @@ public class FigoConnection extends FigoApi {
     public FigoConnection(String clientId, String clientSecret, String redirectUri, int timeout, String apiEndpoint) {
         super(apiEndpoint, buildAuthorizationString(clientId, clientSecret), timeout);
         this.redirectUri = redirectUri;
+        this.clientId = clientId;
     }
 
     private static String buildAuthorizationString(String clientId1, String clientSecret1) {


### PR DESCRIPTION
Hi,
``clientId`` was always null in ``getLoginUrl()``, so I was getting NullpointerExceptions.
It was never set in the constructor, so that's what I did.