### PR TITLE
Fixed failing travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+install: mvn install -Dgpg.skip=true -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test
 jdk:
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ script: mvn test
 jdk:
   - oraclejdk7
   - oraclejdk8
-  - openjdk6
   - openjdk7

--- a/pom.xml
+++ b/pom.xml
@@ -108,9 +108,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
-				<configuration>
-					<skip>false</skip>
-				</configuration>
 				<executions>
 					<execution>
 						<id>sign-artifacts</id>


### PR DESCRIPTION
* skipping  maven-gpg-plugin for travis build
* removed maven-gpg-plugin configuration which prevents skipping from command line
* removed openjdk6 since compiler level is 1.7