### PR TITLE
Force usage of TLSv1.2 protocol for HTTPS connections

### DIFF
--- a/src/main/java/me/figo/FigoApi.java
+++ b/src/main/java/me/figo/FigoApi.java
@@ -41,6 +41,7 @@ import javax.net.ssl.X509TrustManager;
 
 import com.google.gson.Gson;
 
+import me.figo.internal.FigoSocketFactory;
 import me.figo.internal.FigoTrustManager;
 import me.figo.internal.GsonAdapter;
 
@@ -157,7 +158,8 @@ public class FigoApi {
             try {
                 final SSLContext sc = SSLContext.getInstance("SSL");
                 sc.init(null, new TrustManager[] { trustManager }, new java.security.SecureRandom());
-                ((HttpsURLConnection) connection).setSSLSocketFactory(sc.getSocketFactory());
+                FigoSocketFactory figoSocketFactory = new FigoSocketFactory(sc.getSocketFactory());
+                ((HttpsURLConnection) connection).setSSLSocketFactory(figoSocketFactory);
             } catch (NoSuchAlgorithmException e) {
                 throw new IOException("Connection setup failed", e);
             } catch (KeyManagementException e) {

--- a/src/main/java/me/figo/internal/FigoSocketFactory.java
+++ b/src/main/java/me/figo/internal/FigoSocketFactory.java
@@ -1,0 +1,64 @@
+package me.figo.internal;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+/**
+ * Proxies SSLSocketFactory to force use of specific SSL protocols
+ */
+public class FigoSocketFactory extends SSLSocketFactory {
+
+    private static final String[] ENABLED_PROTOCOLS = {"TLSv1.2"};
+
+    private SSLSocketFactory isf;
+
+    public FigoSocketFactory(SSLSocketFactory factory) {
+        isf = factory;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return isf.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return isf.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket socket, String host, int port, boolean autoClose) throws IOException {
+        return enableProtocols(isf.createSocket(socket, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return enableProtocols(isf.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String remoteHost, int remotePort, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return enableProtocols(isf.createSocket(remoteHost, remotePort, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return enableProtocols(isf.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress remoteHost, int remotePort, InetAddress localHost, int localPort) throws IOException {
+        return enableProtocols(isf.createSocket(remoteHost, remotePort, localHost, localPort));
+    }
+
+    private Socket enableProtocols(Socket socket) {
+        if (socket != null && socket instanceof SSLSocket) {
+            ((SSLSocket) socket).setEnabledProtocols(ENABLED_PROTOCOLS);
+        }
+        return socket;
+    }
+}


### PR DESCRIPTION
TLS protocol v1.2 is supported on Java 7, but is disabled by default, and it's
used on Java 8 and later versions by default. So, if a server only supports
TLSv1.2, then Java 7 clients would not be able to connect.

This commit ensures that TLSv1.2 and only TLSv1.2 is used to connect to figo
API endpoints both on Java 7 and Java 8. This also means that if the server
doesn't support TLSv1.2, the connection will now fail, instead of being
downgraded to earlier TLS versions.

Additional explanations will follow by email to @steinke. 

Signed-off-by: Yury V. Zaytsev <yury.zaytsev@moneymeets.com>